### PR TITLE
Add scraper conveniences

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -10,3 +10,6 @@ update-from-cookiecutter:
     --no-input \
     --overwrite-if-exists \
     --output-dir ..
+
+clean:
+  rm -rf **/build **/*.egg-info dist

--- a/admin-docs/scraper-getting-started.md
+++ b/admin-docs/scraper-getting-started.md
@@ -1,0 +1,57 @@
+# Scraper - Getting Started
+
+Use this doc to get started with testing / running the scraper from your local machine.
+
+1. Use Python >= 3.10
+
+    ```sh
+    python3 --version
+    ```
+
+    The version should be something like `Python 3.10.6` (or newer).
+
+2. Set up a virtualenv
+
+    From the root dir of this project:
+
+    ```sh
+    python3 -m venv ./env
+    ```
+
+    This creates a virtual environment so that the project dependencies can be isolated from the rest of your system.
+
+3. Activate the virtual environment
+
+    From the root dir of this project:
+
+    ```sh
+    source ./env/bin/activate
+    ```
+
+    Once the virtualenv is activated, you can verify that the local `python` is in your shell PATH.
+
+    ```sh
+    which python
+    ```
+
+    The path for `python` should be something like...
+
+    `/path/to/this/project/env/bin/python`
+
+4. Install dependencies
+
+    From the root of this project, install the requirements defined in `./python`. (See `./python/setup.py` for the full requirements.)
+
+    ```sh
+    pip install ./python/
+    ```
+
+5. Run the scraper
+
+    After the dependencies are installed, you can run the scraper:
+
+    ```sh
+    python python/cdp_montana_legislature_backend/scraper.py
+    ```
+
+    The scraper supports two arguments to set the datetime span of the events that will be gathered. Use the `-h` flag to see the usage.

--- a/python/cdp_montana_legislature_backend/scraper.py
+++ b/python/cdp_montana_legislature_backend/scraper.py
@@ -1,10 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import logging
 from datetime import datetime
 from typing import List
 
 from cdp_backend.pipeline.ingestion_models import EventIngestionModel
+
+# region logging
+
+log = logging.getLogger("cdp_montana_legislature_scraper")
+log.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+ch.setFormatter(formatter)
+log.addHandler(ch)
+
+# endregion
 
 ###############################################################################
 
@@ -36,5 +49,44 @@ def get_events(
     from GitHub Actions UI.
     """
 
+    log.info("Starting MT Legislature Scraper")
+
     # Your implementation here
     return []
+
+
+if __name__ == "__main__":
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Scape events from MT Legislature")
+    parser.add_argument(
+        "-f",
+        "--from_dt",
+        help="An ISO-8601 timestamp used as the minimum timestamp for gathering events. If not set datetime.min is used.",
+    )
+    parser.add_argument(
+        "-t",
+        "--to_dt",
+        help="An ISO-8601 timestamp used as the maximum timestamp for gathering events. If not set datetime.max is used.",
+    )
+
+    args = parser.parse_args()
+
+    from_dt = datetime.min
+    to_dt = datetime.max
+
+    from dateutil.parser import *
+
+    if args.from_dt is not None:
+        log.debug(f"Parsing from_dt={args.from_dt} as datetime")
+        from_dt = parser.isoparse(args.from_dt)
+
+    if args.to_dt is not None:
+        log.debug(f"Parsing to_dt={args.to_dt} as datetime")
+        to_dt = parser.isoparse(args.to_dt)
+
+    log.debug(f"Using arguments: from_dt={from_dt}, to_dt={to_dt}")
+
+    events = get_events(args.from_dt, args.to_dt)
+    log.info(f"Scraped events: {events}")

--- a/python/cdp_montana_legislature_backend/scraper.py
+++ b/python/cdp_montana_legislature_backend/scraper.py
@@ -10,9 +10,7 @@ from cdp_backend.pipeline.ingestion_models import EventIngestionModel
 # region logging
 
 log = logging.getLogger("cdp_montana_legislature_scraper")
-log.setLevel(logging.DEBUG)
 ch = logging.StreamHandler()
-ch.setLevel(logging.DEBUG)
 ch.setFormatter(
     logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 )
@@ -57,6 +55,8 @@ def get_events(
 
 
 if __name__ == "__main__":
+
+    log.setLevel(logging.DEBUG)
 
     import argparse
 

--- a/python/cdp_montana_legislature_backend/scraper.py
+++ b/python/cdp_montana_legislature_backend/scraper.py
@@ -13,8 +13,9 @@ log = logging.getLogger("cdp_montana_legislature_scraper")
 log.setLevel(logging.DEBUG)
 ch = logging.StreamHandler()
 ch.setLevel(logging.DEBUG)
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-ch.setFormatter(formatter)
+ch.setFormatter(
+    logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+)
 log.addHandler(ch)
 
 # endregion
@@ -44,9 +45,9 @@ def get_events(
 
     Notes
     -----
-    As the implimenter of the get_events function, you can choose to ignore the from_dt
-    and to_dt parameters. However, they are useful for manually kicking off pipelines
-    from GitHub Actions UI.
+    As the implimenter of the get_events function, you can choose to ignore
+    the from_dt and to_dt parameters. However, they are useful for manually
+    kicking off pipelines from GitHub Actions UI.
     """
 
     log.info("Starting MT Legislature Scraper")
@@ -59,16 +60,24 @@ if __name__ == "__main__":
 
     import argparse
 
-    parser = argparse.ArgumentParser(description="Scape events from MT Legislature")
+    parser = argparse.ArgumentParser(
+        description="Scape events from MT Legislature"
+    )
     parser.add_argument(
         "-f",
         "--from_dt",
-        help="An ISO-8601 timestamp used as the minimum timestamp for gathering events. If not set datetime.min is used.",
+        help=(
+            "An ISO-8601 timestamp used as the minimum timestamp for gathering"
+            " events. If not set datetime.min is used."
+        ),
     )
     parser.add_argument(
         "-t",
         "--to_dt",
-        help="An ISO-8601 timestamp used as the maximum timestamp for gathering events. If not set datetime.max is used.",
+        help=(
+            "An ISO-8601 timestamp used as the maximum timestamp for gathering"
+            " events. If not set datetime.max is used."
+        ),
     )
 
     args = parser.parse_args()
@@ -76,7 +85,7 @@ if __name__ == "__main__":
     from_dt = datetime.min
     to_dt = datetime.max
 
-    from dateutil.parser import *
+    from dateutil import parser
 
     if args.from_dt is not None:
         log.debug(f"Parsing from_dt={args.from_dt} as datetime")

--- a/python/cdp_montana_legislature_backend/scraper.py
+++ b/python/cdp_montana_legislature_backend/scraper.py
@@ -60,9 +60,7 @@ if __name__ == "__main__":
 
     import argparse
 
-    parser = argparse.ArgumentParser(
-        description="Scape events from MT Legislature"
-    )
+    parser = argparse.ArgumentParser(description="Scape events from MT Legislature")
     parser.add_argument(
         "-f",
         "--from_dt",

--- a/python/setup.py
+++ b/python/setup.py
@@ -7,6 +7,7 @@ from setuptools import find_packages, setup
 
 requirements = [
     "cdp-backend==3.2.0",
+    "python-dateutil"
 ]
 
 pipeline_requirements = [


### PR DESCRIPTION
This patch adds some conveniences to the scraper implementation so that local development may be more efficient.

- Formatted logging
- A "main" entry point so that `python scraper.py` works (no more reloading repl!)
- Added argparse so that we can pass from_dt and to_dt through the main entry point
- Documented how to "get started" with development on the scraper.