### PR TITLE
Add get_event_source_ids cloud function

### DIFF
--- a/python/api/main.py
+++ b/python/api/main.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+from typing import List
+import functions_framework
+from flask import Request
+from cdp_backend.database import models as db_models
+import fireo
+from google.auth.credentials import AnonymousCredentials
+from google.cloud.firestore import Client
+from flask import jsonify
+
+
+@functions_framework.http
+def get_event_source_ids(request: Request):
+    fireo.connection(
+        client=Client(
+            project="cdp-montana-legislature",
+            credentials=AnonymousCredentials(),
+        )
+    )
+
+    events_with_source_id = list(
+        map(
+            lambda e: {"event_id": e.id,
+                       "external_source_id": e.external_source_id},
+            _get_all_events(),
+        )
+    )
+
+    response = jsonify(events_with_source_id)
+    return response
+
+
+def _get_all_events() -> List[db_models.Event]:
+    return list(db_models.Event.collection.fetch())

--- a/python/api/requirements.txt
+++ b/python/api/requirements.txt
@@ -1,0 +1,1 @@
+functions-framework==3.*


### PR DESCRIPTION
- Connects to `cdp-montana-legislature` using fireo.
- Fetches all events from the datastore and maps to
  a minimal model containing the event ID and the
  External Source ID.

Tested with…

```
% functions-framework --target get_event_source_ids
```

```
% curl localhost:8080
```

Returns an empty array due to no events in index yet.

Once we have some events indexed we can verify
locally and then deploy it to Google Cloud with an
API gateway set up.

MT Legislature Tracker App Needs CDP Event ID and External Source ID #11