### PR TITLE
Use @openmontana/cdp-frontend npm package

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@councildataproject/cdp-frontend": "git://github.com/openmontana/cdp-frontend#main",
+                "@openmontana/cdp-frontend": "^3.1.4",
                 "react": "^16.13.1",
                 "react-dom": "^16.13.1"
             },
@@ -1786,39 +1786,6 @@
                 "npm": "8.x"
             }
         },
-        "node_modules/@councildataproject/cdp-frontend": {
-            "version": "3.1.3",
-            "resolved": "git+ssh://git@github.com/openmontana/cdp-frontend.git#8d619344fb3af009f69e8b37b75c66ead7f0c450",
-            "license": "MIT",
-            "dependencies": {
-                "@councildataproject/cdp-design": "^1.0.4",
-                "@emotion/react": "^11.4.1",
-                "@emotion/styled": "^11.3.0",
-                "@mozilla-protocol/core": "^13.0.1",
-                "firebase": "^9.5.0",
-                "lodash": "^4.17.21",
-                "n-gram": "^2.0.1",
-                "query-string": "^7.0.1",
-                "react-highlight-words": "^0.17.0",
-                "react-localization": "^1.0.17",
-                "react-responsive": "^9.0.0-beta.5",
-                "react-router-dom": "^5.2.0",
-                "react-virtualized": "^9.22.3",
-                "semantic-ui-css": "^2.4.1",
-                "semantic-ui-react": "^2.0.3",
-                "stemr": "^1.0.0",
-                "stopword": "^1.0.11",
-                "video.js": "^7.14.3",
-                "videojs-youtube": "^2.6.1"
-            },
-            "engines": {
-                "node": "16.x",
-                "npm": "8.x"
-            },
-            "peerDependencies": {
-                "react": "^16.8"
-            }
-        },
         "node_modules/@csstools/convert-colors": {
             "version": "1.4.0",
             "dev": true,
@@ -3424,6 +3391,39 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/@openmontana/cdp-frontend": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@openmontana/cdp-frontend/-/cdp-frontend-3.1.4.tgz",
+            "integrity": "sha512-NOwbj/S3dpwByMXQNl1yeIpCMCfC1ngZMIFcWDgNK3JN+3MivhH58MljLaQwpsDVNh1ezJnb8UbBwcEidPTDNw==",
+            "dependencies": {
+                "@councildataproject/cdp-design": "^1.0.4",
+                "@emotion/react": "^11.4.1",
+                "@emotion/styled": "^11.3.0",
+                "@mozilla-protocol/core": "^13.0.1",
+                "firebase": "^9.5.0",
+                "lodash": "^4.17.21",
+                "n-gram": "^2.0.1",
+                "query-string": "^7.0.1",
+                "react-highlight-words": "^0.17.0",
+                "react-localization": "^1.0.17",
+                "react-responsive": "^9.0.0-beta.5",
+                "react-router-dom": "^5.2.0",
+                "react-virtualized": "^9.22.3",
+                "semantic-ui-css": "^2.4.1",
+                "semantic-ui-react": "^2.0.3",
+                "stemr": "^1.0.0",
+                "stopword": "^1.0.11",
+                "video.js": "^7.14.3",
+                "videojs-youtube": "^2.6.1"
+            },
+            "engines": {
+                "node": "16.x",
+                "npm": "8.x"
+            },
+            "peerDependencies": {
+                "react": "^16.8"
             }
         },
         "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -23747,31 +23747,6 @@
         "@councildataproject/cdp-design": {
             "version": "1.0.5"
         },
-        "@councildataproject/cdp-frontend": {
-            "version": "git+ssh://git@github.com/openmontana/cdp-frontend.git#8d619344fb3af009f69e8b37b75c66ead7f0c450",
-            "from": "@councildataproject/cdp-frontend@git://github.com/openmontana/cdp-frontend#main",
-            "requires": {
-                "@councildataproject/cdp-design": "^1.0.4",
-                "@emotion/react": "^11.4.1",
-                "@emotion/styled": "^11.3.0",
-                "@mozilla-protocol/core": "^13.0.1",
-                "firebase": "^9.5.0",
-                "lodash": "^4.17.21",
-                "n-gram": "^2.0.1",
-                "query-string": "^7.0.1",
-                "react-highlight-words": "^0.17.0",
-                "react-localization": "^1.0.17",
-                "react-responsive": "^9.0.0-beta.5",
-                "react-router-dom": "^5.2.0",
-                "react-virtualized": "^9.22.3",
-                "semantic-ui-css": "^2.4.1",
-                "semantic-ui-react": "^2.0.3",
-                "stemr": "^1.0.0",
-                "stopword": "^1.0.11",
-                "video.js": "^7.14.3",
-                "videojs-youtube": "^2.6.1"
-            }
-        },
         "@csstools/convert-colors": {
             "version": "1.4.0",
             "dev": true
@@ -24888,6 +24863,32 @@
                     "version": "1.0.4",
                     "dev": true
                 }
+            }
+        },
+        "@openmontana/cdp-frontend": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@openmontana/cdp-frontend/-/cdp-frontend-3.1.4.tgz",
+            "integrity": "sha512-NOwbj/S3dpwByMXQNl1yeIpCMCfC1ngZMIFcWDgNK3JN+3MivhH58MljLaQwpsDVNh1ezJnb8UbBwcEidPTDNw==",
+            "requires": {
+                "@councildataproject/cdp-design": "^1.0.4",
+                "@emotion/react": "^11.4.1",
+                "@emotion/styled": "^11.3.0",
+                "@mozilla-protocol/core": "^13.0.1",
+                "firebase": "^9.5.0",
+                "lodash": "^4.17.21",
+                "n-gram": "^2.0.1",
+                "query-string": "^7.0.1",
+                "react-highlight-words": "^0.17.0",
+                "react-localization": "^1.0.17",
+                "react-responsive": "^9.0.0-beta.5",
+                "react-router-dom": "^5.2.0",
+                "react-virtualized": "^9.22.3",
+                "semantic-ui-css": "^2.4.1",
+                "semantic-ui-react": "^2.0.3",
+                "stemr": "^1.0.0",
+                "stopword": "^1.0.11",
+                "video.js": "^7.14.3",
+                "videojs-youtube": "^2.6.1"
             }
         },
         "@pmmmwh/react-refresh-webpack-plugin": {

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
         "deploy": "gh-pages -d build"
     },
     "dependencies": {
-        "@councildataproject/cdp-frontend": "git://github.com/openmontana/cdp-frontend#main",
+        "@openmontana/cdp-frontend": "^3.1.4",
         "react": "^16.13.1",
         "react-dom": "^16.13.1"
     },
@@ -30,8 +30,5 @@
             "last 1 firefox version",
             "last 1 safari version"
         ]
-    },
-    "overrides": {
-        "@councildataproject/cdp-frontend": "git://github.com/openmontana/cdp-frontend#main"
     }
 }

--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { App, AppConfigProvider } from "@councildataproject/cdp-frontend";
+import { App, AppConfigProvider } from "@openmontana/cdp-frontend";
 
-import "@councildataproject/cdp-frontend/dist/index.css";
+import "@openmontana/cdp-frontend/dist/index.css";
 
 const config = {
     firebaseConfig: {
@@ -20,7 +20,6 @@ const config = {
 
 ReactDOM.render(
     <div>
-        {/**/}
         <AppConfigProvider appConfig={config}>
             <App />
         </AppConfigProvider>


### PR DESCRIPTION
Using overrides wasn't working quite as we expected, so instead the openmontana/cdp-frontend fork is published as a separate package.

We won't be able to rely on dependabot to get new updates, and cookiecutter might have some issues when updating, but now we can reliably push new builds of the cdp-frontend fork to npm and get those updates in our instance.