### PR TITLE
Fix GitHub Action Failing on 404 Not Found for package

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -23,8 +23,8 @@ jobs:
 
     - name: Install Packages
       run: |
-        sudo apt update
-        sudo apt-get install ffmpeg --fix-missing
+        sudo apt-get update
+        sudo apt-get install -y ffmpeg
 
     - name: Install Python Dependencies
       run: |

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -17,8 +17,8 @@ jobs:
 
     - name: Install Packages
       run: |
-        sudo apt update
-        sudo apt-get install ffmpeg --fix-missing
+        sudo apt-get update
+        sudo apt-get install -y ffmpeg
 
     - name: Install Python Dependencies
       run: |
@@ -29,7 +29,7 @@ jobs:
         cd python/
         flake8 cdp_montana_legislature_backend --count --verbose --show-source --statistics
         black --check cdp_montana_legislature_backend --diff
-  
+
   build-web:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/event-gather-pipeline.yml
+++ b/.github/workflows/event-gather-pipeline.yml
@@ -32,8 +32,8 @@ jobs:
 
     - name: Install Packages
       run: |
-        sudo apt update
-        sudo apt-get install ffmpeg --fix-missing
+        sudo apt-get update
+        sudo apt-get install -y ffmpeg
 
     - name: Install Python Dependencies
       run: |
@@ -58,7 +58,7 @@ jobs:
       run: |
         cd python/
         run_cdp_event_gather event-gather-config.json --parallel
-    
+
     - name: Gather and Process Requested Events - Manual
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |

--- a/.github/workflows/process-special-event.yml
+++ b/.github/workflows/process-special-event.yml
@@ -23,8 +23,8 @@ jobs:
 
     - name: Install Packages
       run: |
-        sudo apt update
-        sudo apt-get install ffmpeg --fix-missing
+        sudo apt-get update
+        sudo apt-get install -y ffmpeg
 
     - name: Install Python Dependencies
       run: |

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -22,8 +22,8 @@ jobs:
 
     - name: Install Packages
       run: |
-        sudo apt update
-        sudo apt-get install ffmpeg --fix-missing
+        sudo apt-get update
+        sudo apt-get install -y ffmpeg
 
     - name: Install Python Dependencies
       run: |
@@ -42,7 +42,7 @@ jobs:
         echo "$GOOGLE_CREDS" > python/google-creds.json
       env:
         GOOGLE_CREDS: ${{ secrets.GOOGLE_CREDENTIALS }}
-    
+
     - name: Run Command
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |


### PR DESCRIPTION
- Remove usage of `--fix-missing` to attempt resolve error in apt get during actions.