### PR TITLE
Skip Bills Actions When AgendaTree Does Not Contain AgendaId

### DIFF
--- a/python/cdp_montana_legislature_backend/scraper.py
+++ b/python/cdp_montana_legislature_backend/scraper.py
@@ -196,11 +196,16 @@ def get_events(
                         # we will continue to try to scrape this video again until there are timestamps.
                         if "agendaId" in parse_qs(parsed_url.query):
                             agenda_id = "A" + parse_qs(parsed_url.query)["agendaId"][0]
-                            agenda_index = [
+                            agenda_indices = [
                                 i
                                 for i, d in enumerate(event_info_json)
                                 if agenda_id in d.values()
-                            ][0]
+                            ]
+                            if len(agenda_indices) > 0:
+                                agenda_index = agenda_indices[0]
+                            else:
+                                logging.warn(f"agenda_id: {agenda_id} not found in AgendaTree from url: {sliq_link}.")
+                                continue
 
                             logging.debug(
                                 f"[{bill.type_number}] agendaId={agenda_id}, agenda_index={agenda_index}"

--- a/python/cdp_montana_legislature_backend/scraper.py
+++ b/python/cdp_montana_legislature_backend/scraper.py
@@ -207,7 +207,9 @@ def get_events(
                             if len(agenda_indices) > 0:
                                 agenda_index = agenda_indices[0]
                             else:
-                                logging.warn(f"agenda_id: {agenda_id} not found in AgendaTree from url: {sliq_link}.")
+                                logging.warn(
+                                    f"agenda_id: {agenda_id} not found in AgendaTree from url: {sliq_link}."
+                                )
                                 continue
 
                             logging.debug(

--- a/python/cdp_montana_legislature_backend/scraper.py
+++ b/python/cdp_montana_legislature_backend/scraper.py
@@ -201,6 +201,9 @@ def get_events(
                                 for i, d in enumerate(event_info_json)
                                 if agenda_id in d.values()
                             ]
+                            # Even when agendaId is present in the query params it might not be present
+                            # in the AgendaTree parsed from the SLIQ page. In that case, we will skip over
+                            # this bill row since we don't know a time-range to constrain the transcript generation
                             if len(agenda_indices) > 0:
                                 agenda_index = agenda_indices[0]
                             else:


### PR DESCRIPTION
We use `agendaId` query param in the SLIQ URL to detect if we should process a bill action so that we can constrain the time range of the videos (which can be many hours long) to a specific time range for generating transcripts for only the part of the video that is relevant to the specific bill action.

However, in some cases the agendaId param _is present_ but then the agendaId is _not present_ in the AgendaTree which contains the actual time range.

In this case, we'll skip the bill action instead of assuming it is always present.