### PR TITLE
Upgrade cdp-backend to 4.1.0.rc0

### DIFF
--- a/infra/requirements.txt
+++ b/infra/requirements.txt
@@ -1,1 +1,1 @@
-cdp-backend==4.0.9
+cdp-backend==4.1.0.rc0

--- a/python/api/requirements.txt
+++ b/python/api/requirements.txt
@@ -1,2 +1,2 @@
 functions-framework==3.*
-cdp-backend==4.0.9
+cdp-backend==4.1.0.rc0

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "cdp-backend[pipeline]==4.0.9",
+    "cdp-backend[pipeline]==4.1.0.rc0",
     "beautifulsoup4",
     "requests",
     "python-dateutil"


### PR DESCRIPTION
- This rc of cdp-backend should improve
  performance / efficiency of event gather.
  Especially for large gather tasks for state
  legislatures, the processing will be more
  stable by storing each session at a time
  instead of persisting results for all sessions
  at the end of the gather task.
- This upgrade may resolve #72.