### PR TITLE
Update cdp-backend to v4.1.0.rc1

### DIFF
--- a/infra/requirements.txt
+++ b/infra/requirements.txt
@@ -1,1 +1,1 @@
-cdp-backend==4.1.0.rc0
+cdp-backend==4.1.0.rc1

--- a/python/api/requirements.txt
+++ b/python/api/requirements.txt
@@ -1,2 +1,2 @@
 functions-framework==3.*
-cdp-backend==4.1.0.rc0
+cdp-backend==4.1.0.rc1

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    "cdp-backend[pipeline]==4.1.0.rc0",
+    "cdp-backend[pipeline]==4.1.0.rc1",
     "beautifulsoup4",
     "requests",
     "python-dateutil"


### PR DESCRIPTION
- Includes fix to skip re-encode
  if video is already h264